### PR TITLE
Resolve several typos in README and comments

### DIFF
--- a/InstructorEmbedding/instructor.py
+++ b/InstructorEmbedding/instructor.py
@@ -31,7 +31,7 @@ class INSTRUCTOR_Pooling(nn.Module):
     :param pooling_mode_cls_token: Use the first token (CLS token) as text representations
     :param pooling_mode_max_tokens: Use max in each dimension over all tokens.
     :param pooling_mode_mean_tokens: Perform mean-pooling
-    :param pooling_mode_mean_sqrt_len_tokens: Perform mean-pooling, but devide by sqrt(input_length).
+    :param pooling_mode_mean_sqrt_len_tokens: Perform mean-pooling, but divide by sqrt(input_length).
     :param pooling_mode_weightedmean_tokens: Perform (position) weighted mean pooling, see https://arxiv.org/abs/2202.08904
     :param pooling_mode_lasttoken: Perform last token pooling, see https://arxiv.org/abs/2202.08904 & https://arxiv.org/abs/2201.10005
     """

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ for pair in text_instruction_pairs:
 customized_embeddings = model.encode(texts_with_instructions)
 ```
 
-And that's it already. We now have a list of numpy arrays with the emebddings.
+And that's it already. We now have a list of numpy arrays with the embeddings.
 
 ```python
 for pair, embedding in zip(text_instruction_pairs, customized_embeddings):
@@ -71,7 +71,7 @@ If you want to calculate customized embeddings for specific sentences, you may f
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Represent the `domain` `text_type` for `task_objective`:
 * `domain` is optional, and it specifies the domain of the text, e.g., science, finance, medicine, etc.
 * `text_type` is required, and it specifies the encoding unit, e.g., sentence, document, paragraph, etc.
-* `task_objective` is optional, and it specifies the objective of emebdding, e.g., retrieve a document, classify the sentence, etc.
+* `task_objective` is optional, and it specifies the objective of embedding, e.g., retrieve a document, classify the sentence, etc.
 
 ### Compute similarities between texts
 You can use **INSTRUCTOR** to compute similarities between two groups of sentences, with **customized embeddings**.
@@ -144,9 +144,9 @@ We explain the arguments in the following:
 All the other arguments are standard `Huggingface's transformers` training arguments, such as `--overwrite_output_dir`, `--num_train_epochs`, `--learning_rate`. For details, refer to [Huggingface transformers](https://github.com/huggingface/transformers) 
 
 ## Evaluation
-We evalute INSTRUCTOR massively on 70 diverse tasks, spanning a wide range of tasks and domains. Specifically, we build our evaluation on three benchmarks, [MTEB](https://huggingface.co/spaces/mteb/leaderboard), [Billboard](https://arxiv.org/abs/2112.04139), and [Prompt Retrieval](https://arxiv.org/abs/2209.01975). We explain the details about running evaluation scripts in the following.
+We evaluate INSTRUCTOR massively on 70 diverse tasks, spanning a wide range of tasks and domains. Specifically, we build our evaluation on three benchmarks, [MTEB](https://huggingface.co/spaces/mteb/leaderboard), [Billboard](https://arxiv.org/abs/2112.04139), and [Prompt Retrieval](https://arxiv.org/abs/2209.01975). We explain the details about running evaluation scripts in the following.
 <!-- * MTEB is a comprehensive embedding evaluation benchmark that aims to provide a holistic view of embedding models.  It combines several conventional benchmarks (e.g., BEIR and STS) and spans a wide range of domain-specific datasets, including science, biology, and medicine. 
-* Prompt Retrieval tasks aim to retrieve a few in-context learning (i.e., demonstration) examples from annotated examples given a test instance. The embedding model is used to encode all annotated examples and to find the few most similar examples to the test instance based on the cosine similarity. We evalute emebddings by measuring the average performance on the downstream tasks. 
+* Prompt Retrieval tasks aim to retrieve a few in-context learning (i.e., demonstration) examples from annotated examples given a test instance. The embedding model is used to encode all annotated examples and to find the few most similar examples to the test instance based on the cosine similarity. We evaluate embeddings by measuring the average performance on the downstream tasks. 
 * Billboard applies INSTRUCTOR to automatic evaluations for text generation tasks. Following [Kasai et al. (2022a)](https://arxiv.org/abs/2112.04139), we measure the cosine similarity between the generated text and each reference text and take the maximum similarity score over all references available. We evaluate all embedding models by the Pearson correlation with the human judgments. -->
 
 ### MTEB

--- a/evaluation/MTEB/mteb/evaluation/evaluators/RetrievalEvaluator.py
+++ b/evaluation/MTEB/mteb/evaluation/evaluators/RetrievalEvaluator.py
@@ -197,7 +197,7 @@ class RetrievalEvaluator(Evaluator):
             top_hits = sorted(queries_result_list[query_itr], key=lambda x: x["score"], reverse=True)
             query_relevant_docs = self.relevant_docs[query_id]
 
-            # Accuracy@k - We count the result correct, if at least one relevant doc is accross the top-k documents
+            # Accuracy@k - We count the result correct, if at least one relevant doc is across the top-k documents
             for k_val in self.accuracy_at_k:
                 for hit in top_hits[0:k_val]:
                     if hit["corpus_id"] in query_relevant_docs:

--- a/evaluation/prompt_retrieval/MetaICL/metaicl/model.py
+++ b/evaluation/prompt_retrieval/MetaICL/metaicl/model.py
@@ -187,7 +187,7 @@ class MetaICLModel(object):
                 if global_step % gradient_accumulation_steps == 0:
                     torch.nn.utils.clip_grad_norm_(self.model.parameters(), max_grad_norm)
 
-                    self.optimizer.step()    # We have accumulated enought gradients
+                    self.optimizer.step()    # We have accumulated enough gradients
                     if self.scheduler is not None:
                         self.scheduler.step()
                     self.model.zero_grad()


### PR DESCRIPTION
Hello!

## Pull Request overview
* Resolve a handful of typos in documentation and comments throughout this repository, including the README.

## Details
The typos were automatically detected using [`codespell`](https://github.com/codespell-project/codespell) and manually fixed if they indeed were a typo.

---

This work is very interesting! Great job on it.

- Tom Aarsen